### PR TITLE
Fix bug with -I Directory

### DIFF
--- a/src/pa_optcomp.ml
+++ b/src/pa_optcomp.ml
@@ -780,7 +780,7 @@ let rec next_token lexer state_ref =
           (* Try to looks up in all include directories *)
           let fname =
             try
-              List.find (fun dir -> Sys.file_exists (Filename.concat dir fname)) !dirs
+              Filename.concat (List.find (fun dir -> Sys.file_exists (Filename.concat dir fname)) !dirs) fname
             with
                 (* Just try in the current directory *)
                 Not_found -> fname


### PR DESCRIPTION
Without the fix, `List.find` returns the directory instead of the full-name of the file (as the Not_found branch would). As a consequence, optcomp will always fail when trying to include a file that is not in the current directory.