### PR TITLE
OCaml 4.06.0 compatibility fix

### DIFF
--- a/src/optcomp.ml
+++ b/src/optcomp.ml
@@ -84,9 +84,9 @@ let rec print mode current_fname current_line current_col files token_stream =
                 (* Go to the right position in the input. *)
                 if pos_in ic <> off then seek_in ic off;
                 (* Read the part to copy. *)
-                let str = String.create len in
-                really_input ic str 0 len;
-                (str, Loc.stop_line loc, Loc.stop_off loc - Loc.stop_bol loc)
+                let buf = Bytes.create len in
+                really_input ic buf 0 len;
+                (Bytes.to_string buf, Loc.stop_line loc, Loc.stop_off loc - Loc.stop_bol loc)
         in
         if current_fname = fname && current_line = line && current_col = col then
           (* If we at the right position, just print the string. *)


### PR DESCRIPTION
Since OCaml 4.06.0 the `-safe-string` has been turned on by default, meaning that strings are immutable (by default). As a further consequence it is no longer meaningful to use strings as mutable character buffers.

This patch uses a bytes buffer rather than string.